### PR TITLE
🐛 Fix reshare theme show page

### DIFF
--- a/app/views/themes/reshare_show/hyrax/base/show.html.erb
+++ b/app/views/themes/reshare_show/hyrax/base/show.html.erb
@@ -1,10 +1,10 @@
 <% provide :page_title, @presenter.page_title %>
 <div class="row work-type">
-  <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
+  <div itemscope itemtype="http://schema.org/CreativeWork" class="col-12">
     <%= render 'work_title', presenter: @presenter %>
     <%= render 'show_actions', presenter: @presenter %>
-    <div class="panel panel-default">
-      <div class="panel-body py-0">
+    <div class="card">
+      <div class="card-body">
         <div class="row">
           <%= render 'workflow_actions_widget', presenter: @presenter %>
           <% if @presenter.video_embed_viewer? %>
@@ -18,21 +18,19 @@
               <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter) %>
             </div>
           <% else %>
-            <div class="col-12 text-center">
-              <%= render 'representative_media', presenter: @presenter, viewer: false %> 
+            <div class="col-sm-3 text-center">
+              <%= render 'representative_media', presenter: @presenter, viewer: false %>
             </div>
           <% end %>
         </div>
-        <div class="row py-4">
-          <div class="col-xs-12">
-            <%= render 'work_description', presenter: @presenter %>
-            <dl class="work-show <%= dom_class(@presenter) %> mb-0" <%= @presenter.microdata_type_to_html %>>
-              <%= render 'attribute_rows', presenter: @presenter %>
-            </dl>
-          </div>
+        <div class="col-sm-9">
+          <%= render 'work_description', presenter: @presenter %>
+          <dl class="work-show <%= dom_class(@presenter) %> mb-0" <%= @presenter.microdata_type_to_html %>>
+            <%= render 'attribute_rows', presenter: @presenter %>
+          </dl>
         </div>
       </div>
-    </div><!-- /panel -->
-    <span class='hide analytics-event' data-category="work" data-action="work-view" data-name="<%= @presenter.id %>" >
+    </div><!-- /.card -->
+    <span class='hide analytics-event' data-category="work" data-action="work-view" data-name="<%= @presenter.id %>" ></span>
   </div>
 </div>


### PR DESCRIPTION
I still had Bootstrap 3 classes on the reshare theme show page so everything looked wonky.  This commit will update the classes so it will look better.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/40

## Before
![image](https://github.com/user-attachments/assets/068d8602-8d7e-4cca-8b72-2818b04a3983)

## After
![image](https://github.com/user-attachments/assets/702a544c-cb98-492e-be0c-ff4b47d0bca0)
