### PR TITLE
🐛 Search Dropdown Menu Styling

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -25,22 +25,16 @@
             <span aria-hidden="true"><%= t("hyrax.search.form.option.all.label_short") %></span>
             <span class="caret"></span>
           </button>
-          <ul class="dropdown-menu pull-right">
-            <li>
-              <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
-                  data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
-            </li>
-            <li>
-              <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#",
-                  data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") } %>
-            </li>
-            <li>
-              <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#",
-                  data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
-            </li>
+          <div class="dropdown-menu dropdown-menu-right">
+            <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#", class: 'dropdown-item',
+                data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
+            <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#", class: 'dropdown-item',
+                data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") }, class: 'dropdown-item' %>
+            <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#", class: 'dropdown-item',
+                data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") }, class: 'dropdown-item' %>
           <% end %>
 
-        </ul>
+        </div>
       </div><!-- /.input-group-btn -->
     </div><!-- /.input-group -->
 


### PR DESCRIPTION
# Story: [i156] Search Dropdown Menu Styling

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/156

## Expected Behavior Before Changes

- Search form dropdown menus missing styles
- Dropdown menu opened on the left side of the search bar
- Dropdown menu lacked margin/padding
- Dropdown links on some themes had `text-decoration:underline` while others did not

## Expected Behavior After Changes

- Search form dropdown opens to the right of the screen, just under the `All` button
- Dropdown menu has pleasant styling
- Dropdown menus on all themes match

## Screenshots / Video

<details>
<summary>Default theme - before</summary>

<img width="1496" alt="Screenshot 2025-01-14 at 3 51 06 PM" src="https://github.com/user-attachments/assets/25b393e7-971b-4784-9213-e9640cc9afd7" />

</details>

<details>

<summary>Default theme - after</summary>

<img width="1491" alt="Screenshot 2025-01-14 at 3 52 28 PM" src="https://github.com/user-attachments/assets/9f9d8810-e28d-46a8-b264-25813c6c0c2b" />


</details>

## Notes

This commit:
- updates dropdown menu styling in the `_search_form.html.erb` override file to match the structure and style of dropdown menu in Hyrax which fixes reported styling errors
- updates the submodule that contains similar fixes to the dropdown menu overrides for the Cultural and Institutional Repository themes