### PR TITLE
🧹 Clean up show pages

### DIFF
--- a/app/assets/stylesheets/palni_palci_overrides/hyku.scss
+++ b/app/assets/stylesheets/palni_palci_overrides/hyku.scss
@@ -167,3 +167,9 @@
 body.splash.splash-index.public-facing.default_home.list_view.default_show {
   margin-bottom: 0;
 }
+
+.cultural_show {
+  .citations-container {
+    display: block;
+  }
+}

--- a/app/views/hyrax/base/_work_description.erb
+++ b/app/views/hyrax/base/_work_description.erb
@@ -1,0 +1,6 @@
+<%# OVERRIDE Hyrax 5.0.1 to enable markdown in the work description, and remove autolink to search in description on show page %>
+
+<% presenter.description.each do |description| %>
+  <%# TODO: not sure why we have to wrap #simple_format, but it doesn't break lines without it while in Hyku it does %>
+  <p class="work_description"><%= simple_format((markdown(description))) %></p>
+<% end %>

--- a/app/views/hyrax/base/_work_type.html.erb
+++ b/app/views/hyrax/base/_work_type.html.erb
@@ -1,0 +1,1 @@
+<%# OVERRIDE Hyrax v5.0.1 to prevent work type from rendering %>

--- a/app/views/themes/cultural_show/hyrax/base/_work_type.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/_work_type.html.erb
@@ -1,0 +1,1 @@
+<%# OVERRIDE Hyrax v5.0.1 to prevent work type from rendering %>

--- a/app/views/themes/scholarly_show/hyrax/base/_work_type.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/_work_type.html.erb
@@ -1,0 +1,8 @@
+<%#
+  This is here because base work_type partial is overridden and scholarly_show should still display the work_type icon
+%>
+
+<div class="work-type-tag">
+  <span class="<%= Hyrax::ModelIcon.css_class_for(presenter.model) %>" aria-hidden="true"></span>
+  <%= presenter.human_readable_type %>
+</div>


### PR DESCRIPTION
This commit will remove work type icon for various themes to match the intented behavior.  The _work_description partial needed to be added to make the return carriages and new line characters work properly.  Most of the changes were done in Hyku so the submodule had to be updated.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/177
