### PR TITLE
🧹 Fix catalog gallery view

### DIFF
--- a/app/assets/stylesheets/palni_palci_overrides/hyku.scss
+++ b/app/assets/stylesheets/palni_palci_overrides/hyku.scss
@@ -173,3 +173,12 @@ body.splash.splash-index.public-facing.default_home.list_view.default_show {
     display: block;
   }
 }
+
+a {
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+  }
+}

--- a/app/helpers/hyrax/override_helper_behavior.rb
+++ b/app/helpers/hyrax/override_helper_behavior.rb
@@ -38,20 +38,5 @@ module Hyrax
       state.add_facet_params("#{facet.keys.first}_sim",
                              facet.values.first)
     end
-
-    def truncate_and_iconify_auto_link(field, show_link = true)
-      if field.is_a? Hash
-        options = field[:config].separator_options || {}
-        text = field[:value].to_sentence(options)
-      else
-        text = field
-      end
-      # this block is only executed when a link is inserted;
-      # if we pass text containing no links, it just returns text.
-      auto_link(html_escape(text)) do |value|
-        "<span class='fa fa-external-link'></span>#{('&nbsp;' + value) if show_link}"
-      end
-      text.truncate(230, separator: ' ')
-    end
   end
 end


### PR DESCRIPTION
This commit will update the Hyku submodule which will bring in the fix for the catalog gallery view.  Also, it removes the truncate_and_iconify_auto_link method because it got contributes back to Hyku.  We are also removing all the underline text decoration from the a tags but keeping the underline for the hover and active effect.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/174
