### PR TITLE
⚙️ Adding a missing yml

### DIFF
--- a/config/sidekiq_auxiliary.yml
+++ b/config/sidekiq_auxiliary.yml
@@ -1,0 +1,7 @@
+---
+:concurrency: <%= ENV['AUXILIARY_WORKER_THREAD_COUNT'] %>
+:queues:
+  - auxiliary
+  - default
+  - import
+  - export


### PR DESCRIPTION
We noticed that the sidekiq_auxiliary.yml is missing from this repo while it is present in the current production env.
