### PR TITLE
temporarily disable pitt jobs until bugs are fixed

### DIFF
--- a/app/models/account_decorator.rb
+++ b/app/models/account_decorator.rb
@@ -14,3 +14,20 @@ Account.superadmin_settings = %i[
 # TODO: Does redeclaring this work?  We'll want to write a test for this.
 Account.setting :contact_email, type: 'string', default: 'consortial-ir@palci.org'
 Account.setting :contact_email_to, type: 'string', default: 'consortial-ir@palci.org'
+
+# Temporarily disable Google Analytics jobs
+# because they are buggy and distruptive
+def find_or_schedule_jobs
+  account = Site.account
+  AccountElevator.switch!(self)
+  [
+    EmbargoAutoExpiryJob,
+    LeaseAutoExpiryJob,
+    # BatchEmailNotificationJob,
+    # DepositorEmailNotificationJob,
+    # UserStatCollectionJob
+  ].each do |klass|
+    klass.perform_later unless find_job(klass)
+  end
+  account ? AccountElevator.switch!(account) : reset!
+end


### PR DESCRIPTION
We need to have a relook at these jobs. They seem to be clogging the backlog and take priority over bulkrax. Additionally there are still existing bugs with the GA4 work so let's just turn these off for now until everything gets resolved. 

When it's good we'll simply remove this code from the decorator 