### PR TITLE
🐛 Carry UV search term via clicking thumbnail

### DIFF
--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,5 +1,0 @@
-<div class="col-md-2">
-  <div class="list-thumbnail">
-    <%= render_thumbnail_tag document, {}, {full_url: true} %>
-  </div>
-</div>


### PR DESCRIPTION
This commit will remove an override so we can use Hyku's default behavior for the thumbnail list in which we can carry over the search term to the UV when clicking on a thumbnail.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/199

![thumbnail-search](https://github.com/user-attachments/assets/b2a5e2f8-a0aa-4260-bb38-b93e9ce338ba)
