### PR TITLE
Remove home text partial

### DIFF
--- a/app/views/hyrax/homepage/_home_text.html.erb
+++ b/app/views/hyrax/homepage/_home_text.html.erb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-<% if display_content_block? @home_text %>
-  <div class="home_page_text">
-    <%= displayable_content_block @home_text, class: 'col-sm-3 home_page_text' %>
-  </div>
-<% end %>


### PR DESCRIPTION
# Story

The home text partial was duplicated from hyku with no functional differences. This commit removes the duplicated partial.

There are no behavioral changes. Each theme already has its own home text partial, so the partial in hyku shouldn't even be used, as home text is not a part of the default theme.
