### PR TITLE
🐛 Hardcode Blacklight.repository_class

### DIFF
--- a/lib/blacklight_decorator.rb
+++ b/lib/blacklight_decorator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# OVERRIDE Blacklight v7.35.0 to hardcode the repository_class to `Blacklight::Solr::Repository`
+#   sometimes in the worker, we're seeing it lose the information from the blacklight.yml
+module BlacklightDecorator
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def repository_class
+      Blacklight::Solr::Repository
+    end
+  end
+end
+
+Blacklight.prepend(BlacklightDecorator)


### PR DESCRIPTION
We're seeing this error sometimes in the worker:
```
RuntimeError (The value for :adapter was not found in the blacklight.yml config)
```

This patch will make the `Blacklight.repository_class` to be hardcoded to `Blacklight::Solr::Repository` to see if it fixes the issue.
