### PR TITLE
Update submodule

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -18,7 +18,7 @@ Rails.application.config.after_initialize do
 
     # WorkType to use as the default if none is specified in the import
     # Default is the first returned by Hyrax.config.curation_concerns
-    # config.default_work_type = MyWork
+    config.default_work_type = GenericWorkResource
 
     # Path to store pending imports
     # config.import_path = 'tmp/imports'


### PR DESCRIPTION
## ⬆️ Update submodule

97b934e23c36e403d075ece9b548eae709299723

This commit will update the submodule to bring in a patch where the solr
adapter is ensured when switching tenants.

## 🧹 Set Bulkrax default work

068ffd6b88ce4d844b911010c8c3c0c68ecfb564

This commit will set the default work for Bulkrax explicitly.  Prior, it
was falling back to Cdl, because by default it looks at the first of the
Hyrax.config.curation_concerns.  Setting it to GenericWorkResource will
make sure if any imports with no explicitly set model that the works
don't create Cdl works instead, which is a very specific work type.

## ⬆️ Update submodule

71040db3d7675c38dabae1659c0ddcd3621657e2

This commit will update the submodule to bring in the latest WillowSword
update in Hyku.

Ref:
- https://github.com/notch8/palni-palci/issues/1014
- https://github.com/notch8/willow_sword/pull/6

## Merge branch 'main' into update-submodule

e4ef0c525b3dd3f5e334a6d02ce9ba786c71c769

