### PR TITLE
OVERRIDE: MigrateResourcesJob to add error handling and logging.

### DIFF
--- a/app/jobs/migrate_resources_job_decorator.rb
+++ b/app/jobs/migrate_resources_job_decorator.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# OVERRIDE: MigrateResourcesJob to add error handling and logging.
+
+module MigrateResourcesJobDecorator
+  def perform(ids: [], models: ['AdminSet', 'Collection'])
+    debugger
+    if ids.blank?
+      models.each do |model|
+        model.constantize.find_each do |item|
+          migrate(item.id)
+        end
+      end
+    else
+      ids.each do |id|
+        migrate(id)
+      end
+    end
+    raise errors.inspect if errors.present?
+  end
+
+  def errors
+    @errors ||= []
+  end
+
+  def migrate(id)
+    begin
+      resource = Hyrax.query_service.find_by(id: id)
+      
+      if resource.wings?
+        errors << "✅ Resource #{id} has already been converted"
+        return
+      end
+      
+      result = MigrateResourceService.new(resource: resource).call
+      errors << result unless result.success?
+      result
+    rescue StandardError => e
+      errors << "😭 Failed to migrate #{id}: #{e.message}"
+    end
+  end
+end
+
+MigrateResourcesJob.prepend(MigrateResourcesJobDecorator)


### PR DESCRIPTION
Jobs seem to be failing silently in production. Hopefully this will reveal a bit more to see what's going on. MigrateResourcesJob should migrate all collections but doesn't.

