### PR TITLE
Override Hyrax's migrate_resources_job with more options

### DIFF
--- a/app/jobs/migrate_resources_job.rb
+++ b/app/jobs/migrate_resources_job.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# OVERRIDE hyrax to fix job... errors seem to stop the job without raising any error
+# - submit a job for each migration
+# - add logging
+# - add permission_template option
+class MigrateResourcesJob < ApplicationJob
+  # @param models [Array>>String] Array of ActiveFedora model names to migrate to valkyrie objects
+  # @param ids [Array>>String or String] Array or string of ids to migrate to valkyrie objects
+  # @param permission_template [Boolean] If true, migrate source_ids from all permission templates
+  # defaults to AdminSet & Collection models if empty (when using rake task "migrate_collections")
+  def perform(ids: [], models: ['AdminSet', 'Collection'], permission_template: false)
+    if ids.is_a?(String) || ids.count == 1
+      migrate(Array.wrap(ids).first)
+    elsif permission_template == true
+      Hyrax::PermissionTemplate.pluck(:source_id).each do |id|
+          MigrateResourcesJob.perform_later(ids: [id.to_s])
+      end
+    elsif ids.count > 1
+      ids.each do |id|
+        MigrateResourceJob.perform_later(ids: [id.to_s])
+      end
+    else
+      models.each do |model|
+        model.constantize.find_each do |item|
+          MigrateResourceJob.perform_later(ids: [item.id.to_s])
+        end
+      end
+    end
+  end
+
+  def migrate(id)
+    Rails.logger.info "🍀 Migrating resource #{id} in tenant #{Site.account.name}"
+    resource = Hyrax.query_service.find_by(id: id)
+    return unless resource.wings? # this resource has already been converted
+    result = MigrateResourceService.new(resource: resource).call
+    if result.success?
+      Rails.logger.info "✅ Migrating resource #{id} successfully"
+    else
+      Rails.logger.info "🚫 Migrating #{id} failed to migrate - #{result}"
+      raise result
+    end
+  end
+end

--- a/app/jobs/migrate_resources_job.rb
+++ b/app/jobs/migrate_resources_job.rb
@@ -2,7 +2,7 @@
 
 # OVERRIDE hyrax to fix job... errors seem to stop the job without raising any error
 # - submit a job for each migration
-# - add logging
+# - add logging messages & rework error handling
 # - add permission_template option
 class MigrateResourcesJob < ApplicationJob
   # @param models [Array>>String] Array of ActiveFedora model names to migrate to valkyrie objects
@@ -10,35 +10,52 @@ class MigrateResourcesJob < ApplicationJob
   # @param permission_template [Boolean] If true, migrate source_ids from all permission templates
   # defaults to AdminSet & Collection models if empty (when using rake task "migrate_collections")
   def perform(ids: [], models: ['AdminSet', 'Collection'], permission_template: false)
-    if ids.is_a?(String) || ids.count == 1
+    if ids.is_a?(String) || ids.count == 1 # migrate a single id
       migrate(Array.wrap(ids).first)
-    elsif permission_template == true
-      Hyrax::PermissionTemplate.pluck(:source_id).each do |id|
-          MigrateResourcesJob.perform_later(ids: [id.to_s])
+    elsif ids.count > 1 # migrate an array of multiple ids
+      submit_ids_migrations(ids)
+    elsif permission_template == true # migrate all admin sets & collections by permission template
+      submit_permission_template_migrations
+    else # migrate all ids based on model name(s)
+      submit_model_migrations(models)
+    end
+  end
+
+  def submit_ids_migrations(ids)
+    ids.each do |id|
+      MigrateResourcesJob.perform_later(ids: [id.to_s])
+    end
+  end
+
+  def submit_permission_template_migrations
+    Hyrax::PermissionTemplate.pluck(:source_id).each do |id|
+      MigrateResourcesJob.perform_later(ids: [id.to_s])
+    end
+  end
+
+  def submit_model_migrations(models)
+    models.each do |model|
+      model.constantize.find_each do |item|
+        # find_each shouldn't find anything Valkyrie but we do to_s to be safe
+        MigrateResourcesJob.perform_later(ids: [item.id.to_s])
       end
-    elsif ids.count > 1
-      ids.each do |id|
-        MigrateResourceJob.perform_later(ids: [id.to_s])
-      end
-    else
-      models.each do |model|
-        model.constantize.find_each do |item|
-          MigrateResourceJob.perform_later(ids: [item.id.to_s])
-        end
-      end
+    rescue => e
+      Rails.logger.error "🚫 Error processing model #{model}: #{e.message}"
     end
   end
 
   def migrate(id)
-    Rails.logger.info "🍀 Migrating resource #{id} in tenant #{Site.account.name}"
-    resource = Hyrax.query_service.find_by(id: id)
+    resource = Hyrax.query_service.find_by(id:)
     return unless resource.wings? # this resource has already been converted
-    result = MigrateResourceService.new(resource: resource).call
+    Rails.logger.info "🍀 Migrating resource #{id} in tenant #{Site.account.name}"
+    result = MigrateResourceService.new(resource:).call
     if result.success?
-      Rails.logger.info "✅ Migrating resource #{id} successfully"
+      Rails.logger.info "✅ Migrated resource #{id} successfully"
     else
-      Rails.logger.info "🚫 Migrating #{id} failed to migrate - #{result}"
+      Rails.logger.error "🚫 Resource #{id} failed to migrate - #{result}"
       raise result
     end
+  rescue Ldp::Gone, Ldp::NotFound, Valkyrie::Persistence::ObjectNotFoundError
+    Rails.logger.error "🚫 Resource #{id} not found"
   end
 end


### PR DESCRIPTION
# Story

Refs https://github.com/notch8/palni_palci_knapsack/issues/253

Errors were not being handled and migrations were being missed.

This implements a way to migrate by permission template source ids and submits each migration as an individual job which should raise an error if the migration fails.

Additional logging has been added to the migration job to help monitor status of migrations.

# Expected Behavior Before Changes

Migration job may fail silently and not all items in a batch get migrated.

# Expected Behavior After Changes

Each migration is submitted as a single job.
Messages are shown logging the migration status.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2025-02-18 at 4 13 26 PM](https://github.com/user-attachments/assets/3e8b7d67-d153-4438-9d76-f27bd60e703e)

![Screenshot 2025-02-18 at 5 47 47 PM](https://github.com/user-attachments/assets/c44ad8ef-6b30-4e9e-8753-6f75e202901e)

</details>

# Notes