### PR TITLE
update-replicas-to-3

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -1,4 +1,4 @@
-replicaCount: 2
+replicaCount: 3
 
 resources:
   limits:


### PR DESCRIPTION
Persisting 3 replicas to help with the organic traffic the sites are seeing, currently scaled to 3 on production, this persists it but will need to be deployed to production.