### PR TITLE
Update submodule again

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,11 @@ services:
       file: hyrax-webapp/docker-compose.yml
       service: fcrepo
 
+  fits: 
+    extends:
+      file: hyrax-webapp/docker-compose.yml
+      service: fits
+
   db:
     extends:
       file: hyrax-webapp/docker-compose.yml


### PR DESCRIPTION
# Story

Brings in a sipity fix from Hyrax. The Migrate Sipity Entry job was running 5 times & failing for new resources which were never in Fedora. This removes that unnecessary behavior.

# Notes