### PR TITLE
Update the helm values to be in line with the update hyrax chart 3.5.1

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -54,10 +54,11 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    cert-manager.io/cluster-issuer: "letsencrypt-production-dns"
+  annotations: {
+    kubernetes.io/ingress.class: "nginx",
+    nginx.ingress.kubernetes.io/proxy-body-size: "0",
+    cert-manager.io/cluster-issuer: letsencrypt-production-dns
+  }
   tls:
     - hosts:
         - hykucommons.org
@@ -115,7 +116,7 @@ extraEnvVars: &envVars
     value: $GOOGLE_OAUTH_PRIVATE_KEY_VALUE
   - name: GOOGLE_OAUTH_CLIENT_EMAIL
     value: hyku-analytics@hyku-analytics-362617.iam.gserviceaccount.com
-  - name: HYKU_ACTIVE_JOB_QUEUE_URL
+  - name: HYRAX_ACTIVE_JOB_QUEUE
     value: sidekiq
   - name: HYKU_ADMIN_HOST
     value: hykucommons.org
@@ -138,6 +139,8 @@ extraEnvVars: &envVars
   - name: HYKU_MULTITENANT
     value: "true"
   - name: HYKU_RESTRICT_CREATE_AND_DESTROY_PERMISSIONS
+    value: "true"
+  - name: HYRAX_FLEXIBLE
     value: "true"
   - name: HYKU_ROOT_HOST
     value: hykucommons.org
@@ -174,7 +177,7 @@ extraEnvVars: &envVars
   - name: PASSENGER_APP_ENV
     value: production
   - name: RAILS_CACHE_STORE_URL
-    value: redis://palni-palci-knapsack-production-redis-master:6379/0
+    value: redis://:$REDIS_PASSWORD@palni-palci-knapsack-production-redis-master:6379/0
   - name: RAILS_ENV
     value: production
   - name: RAILS_LOG_TO_STDOUT
@@ -186,7 +189,9 @@ extraEnvVars: &envVars
   - name: REDIS_HOST
     value: palni-palci-knapsack-production-redis-master
   - name: REDIS_URL
-    value: redis://palni-palci-knapsack-production-redis-master:6379/0
+    value: redis://:$REDIS_PASSWORD@palni-palci-knapsack-production-redis-master:6379/0
+  - name: SECRET_KEY_BASE
+    value: $SECRET_KEY_BASE
   - name: SENTRY_DSN
     value: $SENTRY_DSN
   - name: SENTRY_ENVIRONMENT
@@ -421,14 +426,19 @@ nameOverride: palni-palci-knapsack-production
 fcrepo:
   enabled: false
   servicePort: 8080
+  externalPostgresql:
+    host: palsfcrepo-postgresql.palni-palci-production
   postgresql:
-    password: $DB_PASSWORD
-    auth:
-      password: $DB_PASSWORD
-    enabled: true
+    enabled: false
     image:
       repository: bitnami/postgresql
       tag: 12.17.0-debian-11-r28
+    auth:
+      username: fcrepo
+      password: $DB_PASSWORD
+      database: fcrepo
+    containerPorts:
+      postgresql: 5432
   s3:
     enabled: true
     bucket: besties-fcrepo-clone
@@ -436,8 +446,11 @@ fcrepo:
     secret_key: $AWS_SECRET_ACCESS_KEY
 global:
   hyraxHostName: palni-palci-knapsack-production
+  # These global postgresql values are used by the fcrepo chart
   postgresql:
     auth:
+      username: fcrepo
+      password: $DB_PASSWORD
       postgresPassword: $DB_PASSWORD
 postgresql:
   enabled: false


### PR DESCRIPTION
# Story
Pals was updated to use the updated hyrax 3.5.1 chart but the needed values were not set and the values supplied to the deployment allowed he deployment to succeed but did not allow a proper external fcrepo host connection. This resulted in broken thumbnails (aka the default thumbnail image) on pre-existing work image thumbnails.

On new works thumbnail generation didn't happen during the time the deployment happened last week till the issue was resolved Monday morning, all works that would normally create derivatives, didn't get those derivatives created. 

This fixes the fcrepo connection allowing tenants to create works with images (Excluding PDF's - see note below) and having those images get derivatives created and thumbnails are then seen.

Note: This does not apply to the PDF derivative creation as that is being addressed in a separate PR updating the hyku submodule.

This is what is in line with the hotfix deploy that occured on April 1st 2025 you can see the PR [here](https://github.com/notch8/palni_palci_knapsack/pull/304)

Refs #

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes