### PR TITLE
install-ghostscript-in-the-knapsack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,13 @@ RUN echo "📚 Installing Tesseract Best (training data)!" && \
     wget https://github.com/tesseract-ocr/tessdata_best/raw/main/eng.traineddata -O /usr/share/tessdata/eng_best.traineddata && \
     git config --global --add safe.directory "/app/samvera"
 
+# Knapsack workaround for instllation of ghostscript a requirement of pdf derivative creation process.
+# It is installed in Hyku's Dockerfile but still doesn't get installed in the knapsack. Might be a path issue.
 RUN apt-get update && \
-    apt-get install -y ghostscript
+    apt-get install -y ghostscript && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -s /usr/lib/*-linux-gnu/libjemalloc.so.2 /usr/lib/libjemalloc.so.2 && \
+    echo "******** Packages Installed *********"
 
 USER app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ RUN echo "📚 Installing Tesseract Best (training data)!" && \
 RUN apt-get update && \
     apt-get install -y ghostscript && \
     rm -rf /var/lib/apt/lists/* && \
-    ln -s /usr/lib/*-linux-gnu/libjemalloc.so.2 /usr/lib/libjemalloc.so.2 && \
-    echo "******** Packages Installed *********"
+    echo "******** Ghostscript Installed *********"
 
 USER app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN echo "📚 Installing Tesseract Best (training data)!" && \
     wget https://github.com/tesseract-ocr/tessdata_best/raw/main/eng.traineddata -O /usr/share/tessdata/eng_best.traineddata && \
     git config --global --add safe.directory "/app/samvera"
 
+RUN apt-get update && \
+    apt-get install -y ghostscript
+
 USER app
 
 FROM hyku-knap-base AS hyku-web


### PR DESCRIPTION
# Deployed and Live on Prod as of 4/2/2025

Installing ghostscript inside the knapsack

# Story
Even though updating hyku to install ghostscript works for hyku, it doesn't work for hyku_knapsack. So we have to install it inside the knapsack's Dockerfile for now until we can spend time to figure out why.

Refs # 
https://github.com/samvera/hyku/issues/2509
https://github.com/samvera/hyku/pull/2510

Slack convo:
https://notch8.slack.com/archives/C088B7HJJ1E/p1743532959806629?thread_ts=1743426627.453189&cid=C088B7HJJ1E

# Expected Behavior Before Changes
pdf derivatives we not getting created due to an error with not having ghostscript installed.

# Expected Behavior After Changes
pdf derivatives process will resume.