### PR TITLE
i288 Ensure title is included when searching all fields

### DIFF
--- a/app/controllers/catalog_controller_decorator.rb
+++ b/app/controllers/catalog_controller_decorator.rb
@@ -161,10 +161,11 @@ CatalogController.configure_blacklight do |config|
 
   config.search_fields['all_fields'].clear
   config.add_search_field('all_fields', label: 'All Fields', include_in_advanced_search: false) do |field|
-    all_names = config.show_fields.values.map(&:field).join(" ")
     title_name = 'title_tesim'
+    all_show_names = config.show_fields.values.map(&:field)
+    all_show_names |= [title_name]
     field.solr_parameters = {
-      qf: "#{all_names} file_format_tesim all_text_timv all_text_tsimv",
+      qf: "#{all_show_names.join(" ")} file_format_tesim all_text_timv all_text_tsimv",
       pf: title_name.to_s
     }
   end

--- a/app/controllers/catalog_controller_decorator.rb
+++ b/app/controllers/catalog_controller_decorator.rb
@@ -165,7 +165,7 @@ CatalogController.configure_blacklight do |config|
     all_show_names = config.show_fields.values.map(&:field)
     all_show_names |= [title_name]
     field.solr_parameters = {
-      qf: "#{all_show_names.join(" ")} file_format_tesim all_text_timv all_text_tsimv",
+      qf: "#{all_show_names.join(' ')} file_format_tesim all_text_timv all_text_tsimv",
       pf: title_name.to_s
     }
   end


### PR DESCRIPTION
Recently, title was removed from the catalog show fields (ref c7b8ceb). This caused issues when users were attempting to search a record by its title specifically, including when searching a collection to deposit a work into.

Title should always be included when searching all fields, even if it isn't configured as a show field.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/288
- c7b8ceb