### PR TITLE
Disable rack attack

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -138,6 +138,8 @@ extraEnvVars: &envVars
     value: "true"
   - name: HYKU_MULTITENANT
     value: "true"
+  - name: HYKU_ATTACK_RATE_THROTTLE_OFF
+    value: "true"
   - name: HYKU_RESTRICT_CREATE_AND_DESTROY_PERMISSIONS
     value: "true"
   - name: HYRAX_FLEXIBLE


### PR DESCRIPTION
# Story
Disable Rack::Attack rate throttling in production.

We traced intermittent 500 errors on thumbnail image requests to Errno::ESTALE errors related to file locking on NFS-mounted /app/samvera/file_cache, triggered by Rack::Attack's IP-based request throttling cache.

Although Redis is the active Rails.cache store, Rack::Attack was still falling back to file-based cache in some middleware paths. Setting:
```
  - name: HYKU_ATTACK_RATE_THROTTLE_OFF
    value: "true"
```
disables throttling and prevents Rack::Attack from attempting to read/write lock files in file_cache, avoiding stale NFS file handles.

Refs #issuenumber

# Expected Behavior Before Changes
Thumbnail image requests (GET /downloads/:id?file=thumbnail) would intermittently fail with 500 Internal Server Errors.
Logs showed Errno::ESTALE errors related to file locking in /app/samvera/file_cache.
The root cause was Rack::Attack writing throttling metadata to an NFS-mounted volume, which is not safe for file locks.

# Expected Behavior After Changes
With HYKU_ATTACK_RATE_THROTTLE_OFF=true, Rack::Attack disables throttling middleware entirely.
No more lock attempts on NFS, no more ESTALE errors, and thumbnail endpoints reliably return 200 OK.

# Notes

- This issue was introduced via a Hyku submodule update that added Rack::Attack middleware.
- Although Redis is set as the Rails.cache, Rack::Attack still uses file locking in some cases unless explicitly disabled.
- A more durable fix could involve isolating file_cache to a local (non-NFS) volume or overriding the Rack::Attack cache store explicitly.