### PR TITLE
i323-allow-workflow-state-nil

### DIFF
--- a/app/views/hyrax/dashboard/works/_list_works.html.erb
+++ b/app/views/hyrax/dashboard/works/_list_works.html.erb
@@ -1,0 +1,50 @@
+<%# OVERRIDE Hyrax v5.0.0rc2 to add: %>
+<%# appropriate alt tag, add ENV to control turbolinks, %>
+<%# and use state_label method to huard against nil entries %>
+
+<tr id="document_<%= document.id %>">
+  <td>
+    <label for="batch_document_<%= document.id %>" class="sr-only"><%= t("hyrax.dashboard.my.sr.batch_checkbox") %></label>
+    <%= render 'hyrax/batch_select/add_button', document: document %>&nbsp;
+  </td>
+  <td>
+    <div class='media'>
+      <%= link_to [main_app, document], class: 'mr-2', data: { turbolinks: block_valkyrie_redirect? } do %>
+        <%# OVERRIDE begin %>
+        <%= document_presenter(document)&.thumbnail&.thumbnail_tag(
+          { class: 'd-none d-md-block file_listing_thumbnail', alt: block_for(name: 'default_work_image_text') || "#{document.title_or_label} #{t('hyrax.homepage.admin_sets.thumbnail')}" },
+          { suppress_link: true }
+        ) %>
+        <%# OVERRIDE end %>
+      <% end %>
+
+      <div class='media-body'>
+        <div class='media-heading'>
+
+          <%= link_to [main_app, document], id: "src_copy_link#{document.id}", class: 'document-title', data: { turbolinks: block_valkyrie_redirect? } do %>
+            <span class="sr-only">
+              <%= t("hyrax.dashboard.my.sr.show_label") %>
+            </span>
+            <%= markdown(document.title_or_label) %>
+          <% end %>
+
+          <br />
+          <%= render_collection_links(document) %>
+
+        </div>
+      </div>
+    </div>
+  </td>
+
+  <td class="date text-center"><%= document.date_modified %></td>
+
+  <%# OVERRIDE begin %>
+  <td class='workflow-state text-center'><%= presenter.state_label || "—" %></td>
+  <%# OVERRIDE end %>
+
+  <td class='text-center'><%= render_visibility_link document %></td>
+
+  <td class='text-center'>
+    <%= render 'work_action_menu', document: document %>
+  </td>
+</tr>

--- a/app/views/hyrax/dashboard/works/_list_works.html.erb
+++ b/app/views/hyrax/dashboard/works/_list_works.html.erb
@@ -39,7 +39,7 @@
   <td class="date text-center"><%= document.date_modified %></td>
 
   <%# OVERRIDE begin %>
-  <td class='workflow-state text-center'><%= presenter.state_label || "—" %></td>
+  <td class='workflow-state text-center'><%= presenter.workflow&.state_label || "—" %></td>
   <%# OVERRIDE end %>
 
   <td class='text-center'><%= render_visibility_link document %></td>


### PR DESCRIPTION
Refs #323

# Story
As a Lycoming-IR repository administrator, I need to be able to open the “All Works” dashboard without errors—even when some works have no workflow—so that I can review and manage all items in the tenant.


# Expected Behavior Before Changes
When a work has no associated workflow, navigating to Dashboard → All Works causes a NoMethodError (undefined method state_label for nil:NilClass) because the partial calls:

```
<%= presenter.workflow.state_label %>
```

# Expected Behavior After Changes
Works with no workflow render gracefully—showing blank or a placeholder like “—”—and no error is raised. For example:

```
<%= presenter.workflow&.state_label || "—" %>
```

## Notes:
Update the _list_works.html.erb partial to replace all instances of:

```
presenter.workflow.state_label
```

with

```
<%= presenter.workflow&.state_label || "—" %>
```

The presenter.state_label method already checks for a nil workflow.