### PR TITLE
🧹 Revert GenericWork required fields

### DIFF
--- a/config/metadata/generic_work_resource.yaml
+++ b/config/metadata/generic_work_resource.yaml
@@ -39,14 +39,14 @@ attributes:
       - "keyword_sim"
       - "keyword_tesim"
     form:
-      required: false
+      required: true
       primary: true
     predicate: http://schema.org/keywords
   rights_statement:
     type: string
     multiple: true
     form:
-      required: false
+      required: true
       primary: true
     index_keys:
       - "rights_statement_sim"


### PR DESCRIPTION
This commit will make `rights_statement` and `keyword` required again.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/358

<img width="626" height="435" alt="image" src="https://github.com/user-attachments/assets/1db45b4c-5640-41ac-986b-c5244d8534cc" />
