### PR TITLE
update-chart-version-for-db-wait-fix

### DIFF
--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -24,7 +24,8 @@ DEPLOY_TAG="${DEPLOY_TAG:-latest}"
 WORKER_TAG="${WORKER_TAG:-$DEPLOY_TAG}"
 echo $DEPLOY_TAG
 
-CHART_VERSION="${CHART_VERSION:-3.5.1}"
+CHART_VERSION="${CHART_VERSION:-3.7.1}"
+
 helm pull --untar oci://ghcr.io/samvera/charts/hyrax --version $CHART_VERSION
 helm repo update
 

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -277,7 +277,7 @@ extraDeploy:
               {{- include "hyrax.workerSelectorLabels" . | nindent 8 }}
           spec:
             initContainers:
-              - name: db-wait
+              - name: service-wait
                 image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Chart.AppVersion }}"
                 imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
                 envFrom:
@@ -291,7 +291,7 @@ extraDeploy:
                 command:
                   - sh
                   - -c
-                  - "db-wait.sh {{ include "hyrax.redis.host" . }}:6379"
+                  - "service-wait.sh {{ include "hyrax.redis.host" . }}:6379"
               {{- if .Values.worker.extraInitContainers }}
               {{- toYaml .Values.worker.extraInitContainers | nindent 8 }}
               {{- end }}

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -257,7 +257,7 @@ extraDeploy:
               {{- include "hyrax.workerSelectorLabels" . | nindent 8 }}
           spec:
             initContainers:
-              - name: db-wait
+              - name: service-wait
                 image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Chart.AppVersion }}"
                 imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
                 envFrom:
@@ -271,7 +271,7 @@ extraDeploy:
                 command:
                   - sh
                   - -c
-                  - "db-wait.sh {{ include "hyrax.redis.host" . }}:6379"
+                  - "service-wait.sh {{ include "hyrax.redis.host" . }}:6379"
               {{- if .Values.worker.extraInitContainers }}
               {{- toYaml .Values.worker.extraInitContainers | nindent 8 }}
               {{- end }}

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -291,7 +291,7 @@ extraDeploy:
               {{- include "hyrax.workerSelectorLabels" . | nindent 8 }}
           spec:
             initContainers:
-              - name: db-wait
+              - name: service-wait
                 image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Chart.AppVersion }}"
                 imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
                 envFrom:
@@ -305,7 +305,7 @@ extraDeploy:
                 command:
                   - sh
                   - -c
-                  - "db-wait.sh {{ include "hyrax.redis.host" . }}:6379"
+                  - "service-wait.sh {{ include "hyrax.redis.host" . }}:6379"
               {{- if .Values.worker.extraInitContainers }}
               {{- toYaml .Values.worker.extraInitContainers | nindent 8 }}
               {{- end }}


### PR DESCRIPTION
ref: https://github.com/notch8/palni_palci_knapsack/issues/464

Update chart version to allow fix for db-wait.sh change to service-wait.sh which is what aligns with Hyrax
Update the extradeploy worker aux deployment template to be in line with the service-wait.sh file name change
