### PR TITLE
🐛 Controlled vocabulary fields are dropdowns

### DIFF
--- a/config/initializers/hyrax_controlled_vocabularies_decorator.rb
+++ b/config/initializers/hyrax_controlled_vocabularies_decorator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyku 6.2.0.rc3 to add custom local authorities for flexible=false
+
+module Hyrax
+  module ControlledVocabulariesDecorator
+    extend ActiveSupport::Concern
+    class_methods do
+      def controlled_vocab_mappings
+        super.merge(
+          {
+            'accessibility_feature' => 'accessibility_features',
+            'accessibility_hazard' => 'accessibility_hazards',
+            'contributing_library' => 'contributing_libraries'
+          }
+        )
+      end
+
+      def services
+        super.merge(
+          {
+            'accessibility_features' => 'Hyrax::AccessibilityFeaturesService',
+            'accessibility_hazards' => 'Hyrax::AccessibilityHazardsService',
+            'contributing_libraries' => 'Hyrax::ContributingLibraryService'
+          }
+        )
+      end
+    end
+  end
+end
+
+Hyrax::ControlledVocabularies.prepend(Hyrax::ControlledVocabulariesDecorator)


### PR DESCRIPTION
In v6.2 when flexible=false, the controlled vocabulary fields rendered a text field in the new/edit forms rather than a dropdown. This allowed the user to enter data that did not match a predefined mapping (e.g. `term: "In Copyright"`) defined in the hyku/config/authorities yml files. Controlled vocabulary maps the term from the form dropdown to the id that is persisted (e.g. `id: http://rightsstatements.org/vocab/InC/1.0/`).

Controlled Vocab

- accessibility_feature
- accessibility_hazard
- contributing_library
- license
- resource_type
- rights_statement

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/495
