### PR TITLE
:gift: Makes license a primary term

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ file_cache/
 # we don't want Gemfile lockfile committed in the knapsack
 # It prevents Hyku's gemfile updates from taking effect like they should.
 Gemfile.lock
+.bash_history
+/.cache

--- a/config/metadata/batch_edit_metadata.yaml
+++ b/config/metadata/batch_edit_metadata.yaml
@@ -31,7 +31,7 @@ attributes:
     type: string
     multiple: true
     form:
-      primary: false
+      primary: true
     index_keys:
       - "license_sim"
       - "license_tesim"

--- a/config/metadata/cdl_resource.yaml
+++ b/config/metadata/cdl_resource.yaml
@@ -66,7 +66,7 @@ attributes:
     type: string
     multiple: true
     form:
-      primary: false
+      primary: true
     index_keys:
       - "license_sim"
       - "license_tesim"

--- a/config/metadata/collection_resource.yaml
+++ b/config/metadata/collection_resource.yaml
@@ -162,7 +162,7 @@ attributes:
     type: string
     multiple: true
     form:
-      primary: false
+      primary: true
     index_keys:
       - "license_sim"
       - "license_tesim"

--- a/config/metadata/etd_resource.yaml
+++ b/config/metadata/etd_resource.yaml
@@ -109,7 +109,7 @@ attributes:
     type: string
     multiple: true
     form:
-      primary: false
+      primary: true
     index_keys:
       - "license_sim"
       - "license_tesim"

--- a/config/metadata/generic_work_resource.yaml
+++ b/config/metadata/generic_work_resource.yaml
@@ -66,7 +66,7 @@ attributes:
     type: string
     multiple: true
     form:
-      primary: false
+      primary: true
     index_keys:
       - "license_sim"
       - "license_tesim"

--- a/config/metadata/image_resource.yaml
+++ b/config/metadata/image_resource.yaml
@@ -66,7 +66,7 @@ attributes:
     type: string
     multiple: true
     form:
-      primary: false
+      primary: true
     index_keys:
       - "license_sim"
       - "license_tesim"

--- a/config/metadata/oer_resource.yaml
+++ b/config/metadata/oer_resource.yaml
@@ -104,7 +104,7 @@ attributes:
     type: string
     multiple: true
     form:
-      primary: false
+      primary: true
     index_keys:
       - "license_sim"
       - "license_tesim"


### PR DESCRIPTION
ref: https://notch8.slack.com/archives/C088B7HJJ1E/p1759330797695839?thread_ts=1759263963.503039&cid=C088B7HJJ1E

According to Nic D, license should be a primary term. 